### PR TITLE
fix and add functionality for chipset definitions

### DIFF
--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -3,3 +3,6 @@ lm_sensors::config_file: '/etc/modules'
 lm_sensors::exec_command: '/usr/bin/yes "yes" | /usr/sbin/sensors-detect > /dev/null'
 lm_sensors::package: 'lm-sensors'
 lm_sensors::service_name: 'lm-sensors'
+
+lm_sensors::install::ignore_purge:
+   - '.placeholder'

--- a/manifests/chipset.pp
+++ b/manifests/chipset.pp
@@ -21,14 +21,14 @@ define lm_sensors::chipset (
         owner   => 'root',
         group   => 'root',
         mode    => '0755',
-        require => Package['lm_sensors'];
+        require => Package[$::lm_sensors::package];
       "${::lm_sensors::sensorsd_dir}/chip_${chip}.conf":
         ensure  => $real_ensure,
         owner   => 'root',
         group   => 'root',
         mode    => '0644',
         require => File[$::lm_sensors::sensorsd_dir],
-        notify  => Service['lm_sensors'],
+        notify  => Service[$::lm_sensors::service_name],
         content => template('lm_sensors/chipset.conf');
     }
   }

--- a/manifests/chipset.pp
+++ b/manifests/chipset.pp
@@ -2,7 +2,8 @@
 define lm_sensors::chipset (
   Array $chip_configs,
   Enum['present', 'absent'] $ensure,
-  String $chip = $title,
+  String $chip     = $title,
+  String $filename = '',
 ) {
 
   if $::virtual == 'physical' {
@@ -14,6 +15,12 @@ define lm_sensors::chipset (
       $real_ensure = 'absent'
     }
 
+    if $filename == '' {
+      $_filename = "chip_${chip}"
+    } else {
+      $_filename = $filename
+    }
+
     # create sensors.d dir & chipset file
     file {
       $::lm_sensors::sensorsd_dir:
@@ -22,7 +29,7 @@ define lm_sensors::chipset (
         group   => 'root',
         mode    => '0755',
         require => Package[$::lm_sensors::package];
-      "${::lm_sensors::sensorsd_dir}/chip_${chip}.conf":
+      "${::lm_sensors::sensorsd_dir}/${_filename}.conf":
         ensure  => $real_ensure,
         owner   => 'root',
         group   => 'root',

--- a/manifests/chipset.pp
+++ b/manifests/chipset.pp
@@ -22,14 +22,7 @@ define lm_sensors::chipset (
     }
 
     # create sensors.d dir & chipset file
-    file {
-      $::lm_sensors::sensorsd_dir:
-        ensure  => directory,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0755',
-        require => Package[$::lm_sensors::package];
-      "${::lm_sensors::sensorsd_dir}/${_filename}.conf":
+    file { "${::lm_sensors::sensorsd_dir}/${_filename}.conf":
         ensure  => $real_ensure,
         owner   => 'root',
         group   => 'root',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,4 +14,13 @@ class lm_sensors::install {
     notify  => Service[$lm_sensors::service_name],
     require => Package[$lm_sensors::package],
   }
+
+  # create directory for custom configs
+  file { $::lm_sensors::sensorsd_dir:
+     ensure  => directory,
+     owner   => 'root',
+     group   => 'root',
+     mode    => '0755',
+     require => Package[$::lm_sensors::package];
+  }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,8 @@
 # Install lm_sensors package and scan for sensors
-class lm_sensors::install {
+class lm_sensors::install (
+  Boolean $purge       = false,
+  Array   $ignore_purge = [], 
+) {
   # Install lm_sensors
 
   ensure_packages ($::lm_sensors::package, {
@@ -21,6 +24,9 @@ class lm_sensors::install {
      owner   => 'root',
      group   => 'root',
      mode    => '0755',
+     purge   => $purge,
+     recurse => $purge,
+     ignore  => $ignore_purge,
      require => Package[$::lm_sensors::package];
   }
 }


### PR DESCRIPTION
Before merging, could somebody check if lm_sensors::install::ignore_purge needs to be set on RedHat family systems (on Debian, a file called .placeholder is placed in /etc/sensors.d directory, I do not have a RedHat/centos whatever system currently to check).